### PR TITLE
Changed weights for "Secret" preset

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,9 @@
 - type: weightedRandom
   id: Secret
-  weights:
-    Nukeops: 0.20
-    Traitor: 0.50
+  weights: # Stories
+    Nukeops: 0.15
+    Traitor: 0.55
     Zombie: 0.10
-    Revolutionary: 0.20
-    
+    Revolutionary: 0.05
+    Extended: 0.15
+


### PR DESCRIPTION

## О PR
Изменены вероятности выпадения режимов игры при выборе "Секрета"


## Технические детали
- Предатели                       [50%] -> [55%]
- Ядерные Оперативники [20%] -> [15%]
- Зомби                              [10%] -> [10%]
- Революция                      [20%] -> [5%]
- Расширенный                  [0%] -> [15%]
