### PR TITLE
Имплант Стимултора

### DIFF
--- a/Content.Server/Stories/Implants/InjectImplantSystem.cs
+++ b/Content.Server/Stories/Implants/InjectImplantSystem.cs
@@ -1,44 +1,12 @@
 using Content.Server.Administration.Logs;
-using Content.Server.Body.Systems;
 using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.Explosion.Components;
-using Content.Server.Flash;
-using Content.Server.Flash.Components;
-using Content.Server.Radio.EntitySystems;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Database;
 using Content.Shared.Implants.Components;
-using Content.Shared.Interaction;
-using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
-using Content.Shared.Payload.Components;
-using Content.Shared.Radio;
-using Content.Shared.Slippery;
-using Content.Shared.StepTrigger.Systems;
-using Content.Shared.Trigger;
 using Content.Shared.FixedPoint;
-using Content.Shared.Weapons.Ranged.Events;
-using JetBrains.Annotations;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Containers;
-using Robust.Shared.Physics.Events;
-using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Content.Server.Administration.Logs;
-using Content.Server.Body.Systems;
-using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.Interaction;
-using Content.Server.Popups;
 using Content.Shared.Chemistry;
-using Content.Shared.CombatMode;
-using Content.Shared.DoAfter;
-using Content.Shared.Mobs.Systems;
-using Robust.Shared.Audio.Systems;
 using Content.Shared.IdentityManagement;
-
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Popups;
@@ -79,7 +47,7 @@ namespace Content.Server.Stories.Implants
             if (!component.NotUsedSolutions.ContainsValue(true))
             {
                 // Have no capsules
-                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-message"), user, user);
+                _popup.PopupClient(Loc.GetString("inject-trigger-empty-message"), user, user);
                 return;
             }
 
@@ -97,7 +65,7 @@ namespace Content.Server.Stories.Implants
             // Try get insert solution
             if (!_solutionContainer.TryGetInjectableSolution(user, out var targetSoln, out var targetSolution))
             {
-                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
+                _popup.PopupClient(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
@@ -109,7 +77,7 @@ namespace Content.Server.Stories.Implants
 
             if (realTransferAmount <= 0)
             {
-                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-capsule-message"), user, user);
+                _popup.PopupClient(Loc.GetString("inject-trigger-empty-capsule-message"), user, user);
                 return;
             }
 
@@ -118,14 +86,14 @@ namespace Content.Server.Stories.Implants
 
             if (!targetSolution.CanAddSolution(removedSolution))
             {
-                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
+                _popup.PopupClient(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
             _reactiveSystem.DoEntityReaction(user, removedSolution, ReactionMethod.Injection);
             _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
 
-            _popup.PopupEntity(Loc.GetString("inject-trigger-feel-prick-message"), user, user);
+            _popup.PopupClient(Loc.GetString("inject-trigger-feel-prick-message"), user, user);
 
             // same LogType as syringes...
             _adminLogger.Add(LogType.ForceFeed, $"{_entMan.ToPrettyString(user):user} used inject implant with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution}");

--- a/Content.Server/Stories/Implants/InjectImplantSystem.cs
+++ b/Content.Server/Stories/Implants/InjectImplantSystem.cs
@@ -47,7 +47,7 @@ namespace Content.Server.Stories.Implants
             if (!component.NotUsedSolutions.ContainsValue(true))
             {
                 // Have no capsules
-                _popup.PopupClient(Loc.GetString("inject-trigger-empty-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-message"), user, user);
                 return;
             }
 
@@ -65,7 +65,7 @@ namespace Content.Server.Stories.Implants
             // Try get insert solution
             if (!_solutionContainer.TryGetInjectableSolution(user, out var targetSoln, out var targetSolution))
             {
-                _popup.PopupClient(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
@@ -77,7 +77,7 @@ namespace Content.Server.Stories.Implants
 
             if (realTransferAmount <= 0)
             {
-                _popup.PopupClient(Loc.GetString("inject-trigger-empty-capsule-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-capsule-message"), user, user);
                 return;
             }
 
@@ -86,14 +86,14 @@ namespace Content.Server.Stories.Implants
 
             if (!targetSolution.CanAddSolution(removedSolution))
             {
-                _popup.PopupClient(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
             _reactiveSystem.DoEntityReaction(user, removedSolution, ReactionMethod.Injection);
             _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
 
-            _popup.PopupClient(Loc.GetString("inject-trigger-feel-prick-message"), user, user);
+            _popup.PopupEntity(Loc.GetString("inject-trigger-feel-prick-message"), user, user);
 
             // same LogType as syringes...
             _adminLogger.Add(LogType.ForceFeed, $"{_entMan.ToPrettyString(user):user} used inject implant with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution}");

--- a/Content.Server/Stories/Implants/InjectImplantSystem.cs
+++ b/Content.Server/Stories/Implants/InjectImplantSystem.cs
@@ -1,0 +1,138 @@
+using Content.Server.Administration.Logs;
+using Content.Server.Body.Systems;
+using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Server.Explosion.Components;
+using Content.Server.Flash;
+using Content.Server.Flash.Components;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Database;
+using Content.Shared.Implants.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Payload.Components;
+using Content.Shared.Radio;
+using Content.Shared.Slippery;
+using Content.Shared.StepTrigger.Systems;
+using Content.Shared.Trigger;
+using Content.Shared.FixedPoint;
+using Content.Shared.Weapons.Ranged.Events;
+using JetBrains.Annotations;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Content.Server.Administration.Logs;
+using Content.Server.Body.Systems;
+using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Server.Interaction;
+using Content.Server.Popups;
+using Content.Shared.Chemistry;
+using Content.Shared.CombatMode;
+using Content.Shared.DoAfter;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Audio.Systems;
+using Content.Shared.IdentityManagement;
+
+using Content.Server.Explosion.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Popups;
+using System.Linq;
+
+namespace Content.Server.Stories.Implants
+{
+
+    public sealed partial class InjectImplantSystem : EntitySystem
+    {
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly SolutionContainerSystem _solutionContainer = default!;
+        [Dependency] private readonly IEntityManager _entMan = default!;
+        [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
+        [Dependency] private readonly SolutionContainerSystem _solutionContainers = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<InjectOnTriggerComponent, TriggerEvent>(HandleInjectTrigger);
+        }
+
+        private void HandleInjectTrigger(EntityUid uid, InjectOnTriggerComponent component, TriggerEvent args)
+        {
+
+            // Get user uid
+            if (!TryComp<SubdermalImplantComponent>(uid, out var implantComp) || implantComp.ImplantedEntity is null)
+            {
+                return;
+            }
+            var user = (EntityUid) implantComp.ImplantedEntity;
+
+
+            // Geting inject solutions form many avaible solutions
+            if (!component.NotUsedSolutions.ContainsValue(true))
+            {
+                // Have no capsules
+                _popup.PopupCursor(Loc.GetString("inject-trigger-empty-message"), user);
+                return;
+            }
+
+            var injectSolName = component.NotUsedSolutions.Keys.First<string>();
+            foreach (var (solName, valid) in component.NotUsedSolutions)
+            {
+                if (valid) injectSolName = solName;
+            }
+
+            if (!_solutionContainer.TryGetSolution(uid, injectSolName, out var injectSoln, out var injectSolution))
+            {
+                return;
+            }
+
+            // Try get insert solution
+            if (!_solutionContainer.TryGetInjectableSolution(user, out var targetSoln, out var targetSolution))
+            {
+                _popup.PopupCursor(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user);
+                return;
+            }
+
+            _audio.PlayPvs(component.InjectSound, user);
+
+            component.NotUsedSolutions[injectSolName] = false;
+
+            var realTransferAmount = FixedPoint2.Min(injectSolution.Volume, targetSolution.AvailableVolume);
+
+            if (realTransferAmount <= 0)
+            {
+                _popup.PopupCursor(Loc.GetString("inject-trigger-empty-capsule-message"), user);
+                return;
+            }
+
+            // Move units from injectsolution to targetSolution
+            var removedSolution = _solutionContainer.SplitSolution((Entity<SolutionComponent>) injectSoln, realTransferAmount);
+
+            if (!targetSolution.CanAddSolution(removedSolution))
+            {
+                _popup.PopupCursor(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user);
+                return;
+            }
+
+            _reactiveSystem.DoEntityReaction(user, removedSolution, ReactionMethod.Injection);
+            _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
+
+            _popup.PopupCursor(Loc.GetString("inject-trigger-feel-prick-message"), user);
+
+            // same LogType as syringes...
+            _adminLogger.Add(LogType.ForceFeed, $"{_entMan.ToPrettyString(user):user} used inject implant with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution}");
+
+
+            args.Handled = true;
+        }
+
+    }
+}

--- a/Content.Server/Stories/Implants/InjectImplantSystem.cs
+++ b/Content.Server/Stories/Implants/InjectImplantSystem.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Stories.Implants
             if (!component.NotUsedSolutions.ContainsValue(true))
             {
                 // Have no capsules
-                _popup.PopupCursor(Loc.GetString("inject-trigger-empty-message"), user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-message"), user, user);
                 return;
             }
 
@@ -97,7 +97,7 @@ namespace Content.Server.Stories.Implants
             // Try get insert solution
             if (!_solutionContainer.TryGetInjectableSolution(user, out var targetSoln, out var targetSolution))
             {
-                _popup.PopupCursor(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
@@ -109,7 +109,7 @@ namespace Content.Server.Stories.Implants
 
             if (realTransferAmount <= 0)
             {
-                _popup.PopupCursor(Loc.GetString("inject-trigger-empty-capsule-message"), user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-empty-capsule-message"), user, user);
                 return;
             }
 
@@ -118,14 +118,14 @@ namespace Content.Server.Stories.Implants
 
             if (!targetSolution.CanAddSolution(removedSolution))
             {
-                _popup.PopupCursor(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user);
+                _popup.PopupEntity(Loc.GetString("inject-trigger-cant-inject-message", ("target", Identity.Entity(user, _entMan))), user, user);
                 return;
             }
 
             _reactiveSystem.DoEntityReaction(user, removedSolution, ReactionMethod.Injection);
             _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
 
-            _popup.PopupCursor(Loc.GetString("inject-trigger-feel-prick-message"), user);
+            _popup.PopupEntity(Loc.GetString("inject-trigger-feel-prick-message"), user, user);
 
             // same LogType as syringes...
             _adminLogger.Add(LogType.ForceFeed, $"{_entMan.ToPrettyString(user):user} used inject implant with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution}");

--- a/Content.Server/Stories/Implants/InjectOnTriggerComponent.cs
+++ b/Content.Server/Stories/Implants/InjectOnTriggerComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Audio;
+
+namespace Content.Server.Stories.Implants;
+
+[RegisterComponent]
+public sealed partial class InjectOnTriggerComponent : Component
+{
+    [DataField("solutions")]
+    public Dictionary<string, bool> NotUsedSolutions = new();
+
+    [DataField("injectSound")]
+    public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Items/hypospray.ogg");
+}

--- a/Resources/Locale/ru-RU/stories/inject-implant/implants.ftl
+++ b/Resources/Locale/ru-RU/stories/inject-implant/implants.ftl
@@ -1,0 +1,16 @@
+ent-ChemicalsImplanter = { ent-BaseImplantOnlyImplanter }
+    .desc = { ent-BaseImplantOnlyImplanter.desc }
+    .suffix = Химический
+
+ent-StimulantsImplanter = { ent-BaseImplantOnlyImplanterSyndi }
+    .desc = { ent-BaseImplantOnlyImplanterSyndi.desc }
+    .suffix = Химический
+
+ent-ChemicalImplant = Химический имплант
+    .desc = Вводит в кровь вещества из заранее установленных в имплант капсул
+
+ent-StimulantsImplant = Имплант стимулятора
+    .desc = Вводит в кровь стимулятор из заранее установленных в имплант капсул
+
+ent-ActionChemicalCapsule = Ввести реактивы в кровь
+    .desc = Вводит в кровь вещества из заранее установленных в имплант капсул

--- a/Resources/Locale/ru-RU/stories/inject-implant/inject-implant.ftl
+++ b/Resources/Locale/ru-RU/stories/inject-implant/inject-implant.ftl
@@ -1,0 +1,4 @@
+inject-trigger-empty-message = В импланте нет полных капсул!
+inject-trigger-cant-inject-message = Нельзя сделать инъекцию в { $target }!
+inject-trigger-empty-capsule-message = Капсула в импланте пустая!
+inject-trigger-feel-prick-message = Вы чувствуете как жидкость растекается в вашей крови!

--- a/Resources/Locale/ru-RU/stories/stote/uplink-catalog.ftl
+++ b/Resources/Locale/ru-RU/stories/stote/uplink-catalog.ftl
@@ -1,0 +1,3 @@
+uplink-stimulants-implant-name = { ent-StimulantsImplant }
+
+uplink-stimulants-implant-desc = Продвинутый имплант Cybersun, содержащий три капсулы первокласного стимулирующего вещества, моментально вводимые в кровь по желанию носителя.

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -177,7 +177,7 @@
       range: 1.75
       energyConsumption: 50000
       disableDuration: 10
-      
+
 - type: entity
   parent: BaseSubdermalImplant
   id: ScramImplant

--- a/Resources/Prototypes/Stories/Actions/implants.yml
+++ b/Resources/Prototypes/Stories/Actions/implants.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: ActionChemicalCapsule
+  name: Inject chemicats into bloodstream
+  description: Bring chemicats from small capsules in implant and injure it to bloodstream
+  noSpawn: true
+  components:
+  - type: InstantAction
+    checkCanInteract: false
+    itemIconStyle: BigAction
+    priority: -20
+    useDelay: 5
+    icon:
+      sprite: Objects/Specific/Chemistry/syringe.rsi
+      state: syringe_base0
+    event: !type:ActivateImplantEvent

--- a/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
@@ -6,4 +6,4 @@
   cost:
     Telecrystal: 7
   categories:
-  - UplinkUtility
+  - UplinkImplants

--- a/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
@@ -3,6 +3,7 @@
   name: uplink-stimulants-implant-name
   description: uplink-stimulants-implant-desc
   productEntity: StimulantsImplanter
+  icon: { sprite: /Textures/Objects/Specific/Chemistry/syringe.rsi, state: syringe_base0 }
   cost:
     Telecrystal: 7
   categories:

--- a/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
@@ -5,7 +5,7 @@
   productEntity: StimulantsImplanter
   icon: { sprite: /Textures/Objects/Specific/Chemistry/syringe.rsi, state: syringe_base0 }
   cost:
-    Telecrystal: 7
+    Telecrystal: 12
   categories:
   - UplinkImplants
   conditions:

--- a/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
@@ -8,3 +8,12 @@
     Telecrystal: 7
   categories:
   - UplinkImplants
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+          - SurplusBundle

--- a/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Stories/Catalog/uplink_catalog.yml
@@ -1,0 +1,9 @@
+- type: listing
+  id: UplinkChemicalImplant
+  name: uplink-stimulants-implant-name
+  description: uplink-stimulants-implant-desc
+  productEntity: StimulantsImplanter
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkUtility

--- a/Resources/Prototypes/Stories/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Stories/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: ChemicalsImplanter
+  parent: BaseImplantOnlyImplanter
+  suffix: Chemical
+  components:
+    - type: Implanter
+      implant: ChemicalImplant
+
+- type: entity
+  id: StimulantsImplanter
+  parent: BaseImplantOnlyImplanterSyndi
+  suffix: Stimulants
+  components:
+    - type: Implanter
+      implant: StimulantsImplant

--- a/Resources/Prototypes/Stories/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Stories/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,49 @@
+- type: entity
+  parent: BaseSubdermalImplant
+  id: ChemicalImplant
+  name: Chemical implant
+  description: Inject chemicats to blood stream from small capsules in itself
+  noSpawn: true
+  components:
+    - type: SubdermalImplant
+      implantAction: ActionChemicalCapsule
+    - type: SolutionContainerManager
+    - type: TriggerImplantAction
+    - type: InjectOnTrigger
+    - type: Tag
+      tags:
+        - SubdermalImplant
+        - HideContextMenu
+
+- type: entity
+  parent: ChemicalImplant
+  id: StimulantsImplant
+  name: Stimulants implant
+  description: Inject stimulants to blood stream from small capsules in itself
+  noSpawn: true
+  components:
+    - type: SolutionContainerManager
+      solutions:
+        containerA:
+          reagents:
+          - ReagentId: Stimulants
+            Quantity: 17
+          maxVol: 17
+          canMix: True
+        containerB:
+          reagents:
+          - ReagentId: Stimulants
+            Quantity: 17
+          maxVol: 17
+          canMix: True
+        containerC:
+          reagents:
+          - ReagentId: Stimulants
+            Quantity: 17
+          maxVol: 17
+          canMix: True
+    - type: InjectOnTrigger
+      solutions:
+        containerA: true
+        containerB: true
+        containerC: true


### PR DESCRIPTION
## О PR
В Аплинк синдиката добавлен имплант-стимулятор для ЯО за 12 ТК. Обладатель может 3 раза использовать имплант - ему в кровь вводится 17 единиц стимулятора. 

## Почему / Баланс
Возможность выживать против стан-оружия. Полезно как на ЯО, так и на агентах.

## Технические детали
Реализована система InjectOnTriggerSystem, пригодная для использования любых жидкостей.

## Медиа

![Снимок экрана (8)](https://github.com/MetalSage/space-station-14/assets/146581819/1a1d67f4-bb17-47df-b546-926a69232ce5)




**Changelog**
- Перемещено в импланты
- Изменена иконка
- Стоимость импланта увеличена
- Только для ЯО
