### PR TITLE
Weaponry skill

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.NukeOps;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.Store;
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
 using Robust.Server.Player;
@@ -704,6 +705,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     {
         _metaData.SetEntityName(mob, name);
         EnsureComp<NukeOperativeComponent>(mob);
+        EnsureComp<WeaponrySkillComponent>(mob);
 
         if (profile != null)
             _humanoid.LoadProfile(mob, profile);

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Roles;
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
@@ -191,6 +192,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         _inventory.SpawnItemsOnEntity(chosen, comp.StartingGear);
         var revComp = EnsureComp<RevolutionaryComponent>(chosen);
         EnsureComp<HeadRevolutionaryComponent>(chosen);
+        EnsureComp<WeaponrySkillComponent>(chosen); // Stories
 
         _antagSelection.SendBriefing(chosen, Loc.GetString("head-rev-role-greeting"), Color.CornflowerBlue, revComp.RevStartSound);
     }

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Objectives.Components;
 using Content.Shared.PDA;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Jobs;
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -198,6 +199,9 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         // Change the faction
         _npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
         _npcFaction.AddFaction(traitor, component.SyndicateFaction);
+
+        // Stories, give weapon skill
+        EnsureComp<WeaponrySkillComponent>(traitor);
 
         // Give traitors their objectives
         if (giveObjectives)

--- a/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Components/TrainingWeaponrySkillComponent.cs
+++ b/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Components/TrainingWeaponrySkillComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Server.Stories.Weapons.Ranged.WeaponrySkill.Components;
+
+[RegisterComponent]
+public sealed partial class TrainingWeaponrySkillComponent : Component
+{
+    // How many points needs give skill
+    [ViewVariables(VVAccess.ReadWrite), DataField("pointsRequired")]
+    public float PointsRequired = 100f;
+
+    // How many points user already have
+    [ViewVariables(VVAccess.ReadWrite), DataField("pointsCount")]
+    public float PointsCount = 0;
+}

--- a/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Components/WeaponrySkillTrainerComponent.cs
+++ b/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Components/WeaponrySkillTrainerComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Stories.Weapons.Ranged.WeaponrySkill.Components;
+
+[RegisterComponent]
+public sealed partial class WeaponrySkillTrainerComponent : Component
+{
+    // How many points this weapon gives
+    [ViewVariables(VVAccess.ReadWrite), DataField("givenPoints")]
+    public float GivenPoints = 1f;
+}

--- a/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Systems/TrainingWeaponrySkillSystem.cs
+++ b/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Systems/TrainingWeaponrySkillSystem.cs
@@ -1,0 +1,52 @@
+using Content.Server.Stories.Weapons.Ranged.WeaponrySkill.Components;
+using Content.Shared.Projectiles;
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Server.Stories.Weapons.Ranged.WeaponrySkill.Systems;
+
+public sealed class TrainingWeaponrySkillSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // Laser training weapon
+        SubscribeLocalEvent<WeaponrySkillTrainerComponent, GunShotEvent>(OnTrainingShot);
+
+        // Training bullets
+        SubscribeLocalEvent<WeaponrySkillTrainerComponent, ProjectileHitEvent>(OnTrainingProjectileShot);
+    }
+
+    private void OnTrainingShot(EntityUid uid, WeaponrySkillTrainerComponent component, GunShotEvent args)
+    {
+        EntityUid shooter = args.User;
+        TryTraining(component, shooter);
+    }
+
+    private void OnTrainingProjectileShot(EntityUid uid, WeaponrySkillTrainerComponent component, ProjectileHitEvent args)
+    {
+        EntityUid shooter = args.Shooter!.Value;
+        TryTraining(component, shooter);
+    }
+
+    private void TryTraining(WeaponrySkillTrainerComponent component, EntityUid shooter)
+    {
+        // Checking if shooter trained already
+        if (HasComp<WeaponrySkillComponent>(shooter))
+            return;
+
+        // Checking if shooter already training
+        EnsureComp<TrainingWeaponrySkillComponent>(shooter, out var trainingComp);
+
+        // Adding training points after shoot
+        trainingComp.PointsCount += component.GivenPoints;
+
+        // Stop training and weaponry skill
+        if (trainingComp.PointsCount >= trainingComp.PointsRequired)
+        {
+            EnsureComp<WeaponrySkillComponent>(shooter);
+            RemComp<TrainingWeaponrySkillComponent>(shooter);
+        }
+    }
+}

--- a/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Systems/WeaponrySkillSystem.cs
+++ b/Content.Server/Stories/Weapons/Ranged/WeaponrySkill/Systems/WeaponrySkillSystem.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Systems;
+
+namespace Content.Server.Stories.Weapons.Ranged.WeaponrySkill.Systems;
+
+public sealed class WeaponrySkillSystem : SharedWeaponrySkillSystem
+{
+}

--- a/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/RequiresWeaponrySkillComponent.cs
+++ b/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/RequiresWeaponrySkillComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
+
+/// <summary>
+/// Applies accuracy debuff if you don't have weaponry skill
+/// </summary>
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedWeaponrySkillSystem))]
+public sealed partial class RequiresWeaponrySkillComponent : Component  
+{
+    [ViewVariables(VVAccess.ReadWrite), DataField("additionalMinAngle"), AutoNetworkedField]
+    public Angle AdditionalMinAngle = Angle.FromDegrees(45);
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("additionalMaxAngle"), AutoNetworkedField]
+    public Angle AdditionalMaxAngle = Angle.FromDegrees(45);
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("fireSpeedModifier"), AutoNetworkedField]
+    public float FireSpeedModifier = 0.65f;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public EntityUid? WeaponEquipee; 
+}

--- a/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/RequiresWeaponrySkillComponent.cs
+++ b/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/RequiresWeaponrySkillComponent.cs
@@ -8,17 +8,33 @@ namespace Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
 /// </summary>
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedWeaponrySkillSystem))]
-public sealed partial class RequiresWeaponrySkillComponent : Component  
+public sealed partial class RequiresWeaponrySkillComponent : Component
 {
+    // Max degree on shooting start
     [ViewVariables(VVAccess.ReadWrite), DataField("additionalMinAngle"), AutoNetworkedField]
-    public Angle AdditionalMinAngle = Angle.FromDegrees(45);
+    public Angle AdditionalMinAngle = Angle.FromDegrees(2);
 
+    // Max degree on shooting continious
     [ViewVariables(VVAccess.ReadWrite), DataField("additionalMaxAngle"), AutoNetworkedField]
     public Angle AdditionalMaxAngle = Angle.FromDegrees(45);
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("fireSpeedModifier"), AutoNetworkedField]
-    public float FireSpeedModifier = 0.65f;
+    // Degree increase per shoot
+    [ViewVariables(VVAccess.ReadWrite), DataField("angleIncrease"), AutoNetworkedField]
+    public Angle AngleIncrease = Angle.FromDegrees(5);
 
+    // Degree decaying per second
+    [ViewVariables(VVAccess.ReadWrite), DataField("angleDecay"), AutoNetworkedField]
+    public Angle AngleDecay = Angle.FromDegrees(6);
+
+    // Firerate decrease
+    [ViewVariables(VVAccess.ReadWrite), DataField("fireSpeedModifier"), AutoNetworkedField]
+    public float FireSpeedModifier = 0.7f;
+
+    // if enabled
+    [ViewVariables(VVAccess.ReadWrite), DataField("enabled")]
+    public bool Enabled = true;
+
+    // Weapon's owner 
     [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid? WeaponEquipee; 
 }

--- a/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/WeaponrySkillComponent.cs
+++ b/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Components/WeaponrySkillComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
+
+[RegisterComponent]
+public sealed partial class WeaponrySkillComponent : Component
+{
+}

--- a/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Systems/SharedWeaponrySkillSystem.cs
+++ b/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Systems/SharedWeaponrySkillSystem.cs
@@ -1,0 +1,50 @@
+using Content.Shared.Coordinates;
+using Content.Shared.Hands;
+using Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared.Stories.Weapons.Ranged.WeaponrySkill.Systems;
+
+public abstract class SharedWeaponrySkillSystem : EntitySystem
+{
+    [Dependency] private readonly SharedGunSystem _gunSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RequiresWeaponrySkillComponent, GotEquippedHandEvent>(OnEquip);
+        SubscribeLocalEvent<RequiresWeaponrySkillComponent, GotUnequippedHandEvent>(OnUnequip);
+
+        SubscribeLocalEvent<RequiresWeaponrySkillComponent, GunRefreshModifiersEvent>(OnGunRefresh);
+
+    }
+
+    // Добавляем владельца и запускаем обновление характеристик оружия
+    private void OnEquip(EntityUid uid, RequiresWeaponrySkillComponent component, GotEquippedHandEvent args)
+    {
+        component.WeaponEquipee = args.User;
+        _gunSystem.RefreshModifiers(uid);
+    }
+
+    private void OnUnequip(EntityUid uid, RequiresWeaponrySkillComponent component, GotUnequippedHandEvent args)
+    {
+        component.WeaponEquipee = null;
+        _gunSystem.RefreshModifiers(uid);
+    }
+
+    // При обновлении характеристики добавляем баффы
+    private void OnGunRefresh(EntityUid uid, RequiresWeaponrySkillComponent component, ref GunRefreshModifiersEvent args)
+    {
+        if (component.WeaponEquipee == null)
+            return;
+
+        if (HasComp<WeaponrySkillComponent>(component.WeaponEquipee))
+            return;
+
+        args.MinAngle += component.AdditionalMinAngle;
+        args.MaxAngle += component.AdditionalMaxAngle;
+        args.FireRate *= component.FireSpeedModifier;
+
+    }  
+}

--- a/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Systems/SharedWeaponrySkillSystem.cs
+++ b/Content.Shared/Stories/Weapons/Ranged/WeaponrySkill/Systems/SharedWeaponrySkillSystem.cs
@@ -39,10 +39,15 @@ public abstract class SharedWeaponrySkillSystem : EntitySystem
         if (component.WeaponEquipee == null)
             return;
 
+        if (!component.Enabled)
+            return;
+
         if (HasComp<WeaponrySkillComponent>(component.WeaponEquipee))
             return;
 
         args.MinAngle += component.AdditionalMinAngle;
+        args.AngleDecay += component.AngleDecay;
+        args.AngleIncrease += component.AngleIncrease;
         args.MaxAngle += component.AdditionalMaxAngle;
         args.FireRate *= component.FireSpeedModifier;
 

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -34,7 +34,7 @@
         - NamesFirstMilitaryLeader
         - NamesLastMilitary
     - type: InitialInfectedExempt
-
+    - type: WeaponrySkill
 
 ## ERT Leader
 
@@ -70,6 +70,7 @@
       - NamesFirstMilitaryLeader
       - NamesLastMilitary
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVA
@@ -96,6 +97,7 @@
     - type: Loadout
       prototypes: [ ERTLeaderGearEVA ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTLeaderEVALecter
@@ -118,6 +120,7 @@
     - type: Loadout
       prototypes: [ ERTLeaderGearEVALecter ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## ERT Janitor
 
@@ -153,6 +156,7 @@
     - type: Loadout
       prototypes: [ ERTJanitorGear ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTJanitorEVA
@@ -178,6 +182,7 @@
     - type: Loadout
       prototypes: [ ERTJanitorGearEVA ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## ERT Engineer
 
@@ -213,6 +218,7 @@
     - type: Loadout
       prototypes: [ ERTEngineerGear ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTEngineerEVA
@@ -238,6 +244,7 @@
     - type: Loadout
       prototypes: [ ERTEngineerGearEVA ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## ERT Security
 
@@ -273,6 +280,7 @@
     - type: Loadout
       prototypes: [ ERTSecurityGear ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTSecurityEVA
@@ -298,6 +306,7 @@
     - type: Loadout
       prototypes: [ ERTSecurityGearEVA ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTSecurityEVALecter
@@ -319,6 +328,7 @@
     - type: Loadout
       prototypes: [ ERTSecurityGearEVALecter ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## ERT Medic
 
@@ -354,6 +364,7 @@
     - type: Loadout
       prototypes: [ ERTMedicalGear ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerERTMedicalEVA
@@ -379,6 +390,7 @@
     - type: Loadout
       prototypes: [ ERTMedicalGearEVA ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## CBURN
 
@@ -409,6 +421,8 @@
       - NamesFirstMilitary
       - NamesLastMilitary
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
+
 ## Central Command
 
 - type: entity
@@ -433,6 +447,7 @@
     - type: Loadout
       prototypes: [ CentcomGear ]
     - type: InitialInfectedExempt
+    - type: WeaponrySkill
 
 ## Syndicate
 
@@ -453,6 +468,7 @@
   components:
     - type: Loadout
       prototypes: [SyndicateOperativeGearExtremelyBasic]
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerNukeOp
@@ -468,6 +484,7 @@
   id: NukeOp
   components:
     - type: NukeOperative
+    - type: WeaponrySkill
 
 - type: entity
   id: RandomHumanoidSpawnerCluwne

--- a/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/terminator.yml
@@ -107,6 +107,7 @@
     - DoorBumpOpener
     - Unimplantable # no brain to mindshield, no organic body to implant into
   - type: TTS # Stories-TTS
+  - type: WeaponrySkill
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -47,3 +47,4 @@
     - Belt
   - type: UseDelay
     delay: 1
+  - type: RequiresWeaponrySkill

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -236,6 +236,7 @@
     fireCost: 62.5
   - type: StaticPrice
     price: 300
+  - type: WeaponrySkillTrainer
 
 - type: entity
   name: pulse pistol
@@ -509,6 +510,7 @@
     - type: ProjectileBatteryAmmoProvider
       proto: BulletDisablerPractice
       fireCost: 100
+    - type: WeaponrySkillTrainer
 
 - type: entity
   name: taser

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -30,6 +30,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: RequiresWeaponrySkill
 
 - type: entity
   id: BaseWeaponPowerCell
@@ -65,6 +66,7 @@
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot
+  - type: RequiresWeaponrySkill
 
 - type: entity
   id: BaseWeaponBatterySmall

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
@@ -44,6 +44,7 @@
       projectiles: !type:ContainerSlot
   - type: ContainerAmmoProvider
     container: projectiles
+  - type: RequiresWeaponrySkill
 
 - type: entity
   id: BowImprovised

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -19,6 +19,7 @@
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
   - type: StaticPrice
     price: 500
+  - type: RequiresWeaponrySkill
   # No chamber because HMG may want its own
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -60,7 +60,8 @@
     price: 500
   - type: UseDelay
     delay: 1
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: L6 SAW
   id: WeaponLightMachineGunL6

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -19,7 +19,8 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: china lake
   parent: BaseWeaponLauncher

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -65,7 +65,8 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: viper
   parent: BaseWeaponPistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -103,6 +103,8 @@
     damage:
       types:
         Blunt: 2
+  - type: WeaponrySkillTrainer
+    givenPoints: 4
 
 - type: entity
   id: BaseBulletRubber

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -49,7 +49,8 @@
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: Deckard
   parent: BaseWeaponRevolver

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -49,7 +49,8 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: AKMS
   parent: BaseWeaponRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -54,7 +54,8 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: Atreides
   parent: BaseWeaponSubMachineGun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -42,7 +42,8 @@
         ents: []
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: Bulldog
   # Don't parent to BaseWeaponShotgun because it differs significantly

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -36,7 +36,8 @@
         ents: []
   - type: StaticPrice
     price: 500
-
+  - type: RequiresWeaponrySkill
+  
 - type: entity
   name: Kardashev-Mosin
   parent: BaseWeaponSniper

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -17,7 +17,11 @@
   - Salvage
   - Maintenance
   - External
-
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
+      
 - type: startingGear
   id: SalvageSpecialistGear
   equipment:

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -33,6 +33,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: WeaponrySkill
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -57,6 +57,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: WeaponrySkill
 
 - type: startingGear
   id: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -23,6 +23,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -38,6 +38,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: WeaponrySkill
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -21,6 +21,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -23,6 +23,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
 
 - type: startingGear
   id: WardenGear

--- a/Resources/Prototypes/Stories/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/Security/senior_officer.yml
@@ -32,6 +32,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
 
 - type: startingGear
   id: SeniorOfficerGear

--- a/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/head_of_space_prison.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/head_of_space_prison.yml
@@ -34,6 +34,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: WeaponrySkill
 
 - type: startingGear
   id: HeadOfSpacePrisonGear

--- a/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_engineer.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_engineer.yml
@@ -27,7 +27,10 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
-
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
+      
 - type: startingGear
   id: SpacePrisonEngineerGear
   equipment:

--- a/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_medic.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_medic.yml
@@ -30,7 +30,10 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
-
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
+      
 - type: startingGear
   id: SpacePrisonMedicGear
   equipment:

--- a/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_officer.yml
+++ b/Resources/Prototypes/Stories/Roles/Jobs/SpacePrison/space_prison_officer.yml
@@ -22,6 +22,9 @@
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]
+  - !type:AddComponentSpecial
+    components:
+      - type: WeaponrySkill
 
 - type: startingGear
   id: SpacePrisonOfficerGear


### PR DESCRIPTION
## О PR
Геймплейный навык владения оружием, а также методы его получения
Навык имеется у всех тех, у кого был РП навык владения оружием, включая антагонистов и роли призраков
Обучение навыку происходит при стрельбе из тренировочного оружия или тренировочными боеприпасами (скорость обучения 1:4)

## Почему / Баланс
У нас появляется все больше антагонистов, а РП навык владения оружием устарел. Это обновление даст игрокам возможность пользоваться всеми видами оружия без угрозы наказания, при этом ослабляя тех игроков, которые изначально не должны уметь пользоваться оружием.

## Технические детали
Добавлены компоненты WeaponrySkill, RequiresWeaponrySkill, TrainingWeaponrySkill, WeaponrySkillTrainer. 
Первый отвечает за сам навык, второй - требование к навыку на оружии, третий - за сам процесс обучения, четвертый - за оружие или патрон, который обучает игрока

Система ловит подбирании или опускание оружия из рук, изменяя параметры оружия, увеличивая максимальный угол и скорость увеличения угла разброса
Система обучения проверяет, есть ли на оружии компонент WeaponrySkillTrainer при выстреле или при попадании снаряда. Если есть - повышает количество очков игрока на 1/4. При получении 100 очков, убирает компонента обучения и дает навык владения оружием

## Медиа

https://github.com/MetalSage/space-station-14/assets/115770678/16c551d9-2980-41f8-bc54-b74dd02c55ad

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**

:cl:
- add: Добавлен навык владения оружием
